### PR TITLE
Pre-commit instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ so it the code is automatically formatted on each commit. In the repo's dir run:
 
 ```sh
 echo '#!/bin/sh
-dotnet format game-off-2022.sln --include $(git diff --name-only --cached)' > .git/hooks/pre-commit\
+set -eo pipefail
+FILES=$(git diff --name-only --cached)
+dotnet format game-off-2022.sln --include $FILES
+git add $FILES' > .git/hooks/pre-commit\
 chmod +x .git/hooks/pre-commit
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Repository for our [Game Off 2022](https://itch.io/jam/game-off-2022) jam entry.
 
 ## Setup with VSCode
 
-- Install [Mono]()
+Note: both Mono and .NET SDK links refer to Apple Silicon versions, but you can install others.
+
+- Install [Mono](https://www.mono-project.com/download/stable/#download-mac)
 - Install [.NET Core SDK](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/sdk-6.0.402-macos-arm64-installer?journey=vs-code)
 - Install the [VSCode C# Plugin](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - Install the [VSCode C# Gogot Plugin](https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Game Off 2022
-Repository for our [Game Off 2022](https://itch.io/jam/game-off-2022) jam entry
+
+Repository for our [Game Off 2022](https://itch.io/jam/game-off-2022) jam entry.
+
+## Setup with VSCode
+
+- Install [Mono]()
+- Install [.NET Core SDK](https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/sdk-6.0.402-macos-arm64-installer?journey=vs-code)
+- Install the [VSCode C# Plugin](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+- Install the [VSCode C# Gogot Plugin](https://marketplace.visualstudio.com/items?itemName=neikeq.godot-csharp-vscode)
+
+### git pre-commit hook
+
+We use the dotnet formatter to format the code. You can setup a pre-commit hook
+so it the code is automatically formatted on each commit. In the repo's dir run:
+
+```sh
+echo '#!/bin/sh
+dotnet format game-off-2022.sln --include $(git diff --name-only --cached)' > .git/hooks/pre-commit\
+chmod +x .git/hooks/pre-commit
+```

--- a/player/Player.cs
+++ b/player/Player.cs
@@ -7,6 +7,7 @@ public class Player : KinematicBody2D
     [Export] private bool shouldSlide = false;
 
     private bool isRunning = false;
+    private bool teste = false;
 
     public override void _PhysicsProcess(float delta)
     {

--- a/player/Player.cs
+++ b/player/Player.cs
@@ -7,7 +7,6 @@ public class Player : KinematicBody2D
     [Export] private bool shouldSlide = false;
 
     private bool isRunning = false;
-    private bool teste = false;
 
     public override void _PhysicsProcess(float delta)
     {


### PR DESCRIPTION
Adding instructions on how to set up a pre-commit hook to format the code. It's not perfect as it doesn't filter for only cs files but I can tackle that in the future.